### PR TITLE
Unpin pbr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 argparse
 cli_tools
-pbr>=0.6,!=0.7,<1.0
+pbr
 PyGithub


### PR DESCRIPTION
A recent update to setuptools results in the triggering of a pbr bug
which has been fixed in recent versions of pbr.  This removes the pin
on the version of pbr.
